### PR TITLE
Updated line 580

### DIFF
--- a/dist/rbac.js
+++ b/dist/rbac.js
@@ -577,7 +577,7 @@ var RBAC = (function () {
           return cb(err);
         }
 
-        for (var i = 0; i < items.length; i++) {
+        for(var i in items) {
           var item = items[i];
           var _name = item.name;
 


### PR DESCRIPTION
When I call the getScope API, items object is null for all other roles. I was able to use the module by replacing the old format of for loop by the new for loop.

Please refer https://github.com/seeden/rbac/issues/10 for details.