### PR TITLE
Fix express middleware

### DIFF
--- a/controllers/express.js
+++ b/controllers/express.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var WebError = require('web-error');
+var WebError = require('web-error').default;
 
 /**
  * Return middleware function for permission check

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "async": "^1.5.2",
     "keymirror": "^0.1.1",
     "lodash": "^4.5.1",
-    "web-error": "^3.1.2"
+    "web-error": "^4.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",


### PR DESCRIPTION
Fixes #19 by updating [web-error](https://github.com/seeden/web-error) to `^4.0.1` and using `.default` in express controller.