### PR TITLE
fix: require default

### DIFF
--- a/example/simple.js
+++ b/example/simple.js
@@ -1,4 +1,4 @@
-var RBAC = require('./../src/RBAC');
+var RBAC = require('./../src/RBAC').default;
 
 var rbac = new RBAC();
 


### PR DESCRIPTION
require the es6 module with default